### PR TITLE
タスク一覧を作成日時の順番で並び替え

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -2,7 +2,7 @@ class TasksController < ApplicationController
   before_action :set_task, only: [:show, :edit, :update, :destroy]
 
   def index
-    @tasks = Task.all
+    @tasks = Task.all.order(created_at: :desc)
   end
 
   def new

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -4,11 +4,13 @@
   <tr>
     <th><%= t('.name') %></th>
     <th><%= t('.content') %></th>
+    <th><%= t('.created_at') %></th>
   </tr>
   <% @tasks.each do |task| %>
   <tr>
     <td><%= task.name %></td>
     <td><%= task.content %></td>
+    <td><%= task.created_at %></td>
     <td id="show"><%= link_to t('.show_task'), task_path(task.id) %></td>
     <td><%= link_to t('.show_edit'), edit_task_path(task.id), data: { confirm: '本当に編集していいですか？' } %></td>
     <td><%= link_to t('.show_destroy'), task_path(task.id), method: :delete, data: { confirm: '本当に削除していいですか？' } %></td>

--- a/config/locales/models/task/ja.yml
+++ b/config/locales/models/task/ja.yml
@@ -8,7 +8,7 @@ ja:
         name: タスク名
         content: タスク詳細
         id: ID
-        created_at: 登録日時
+        created_at: 作成日時
         update_at: 更新日時
     errors:
       models:

--- a/config/locales/views/tasks/ja.yml
+++ b/config/locales/views/tasks/ja.yml
@@ -8,6 +8,7 @@ ja:
       show_edit: 編集をする
       show_destroy: 削除する
       create_task: 新しくタスクを作成する
+      created_at: 作成日時
     show:
       title: タスク詳細
       name: タスク名

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -1,0 +1,17 @@
+# 「FactoryBotを使用します」という記述
+FactoryBot.define do
+
+  # 作成するテストデータの名前を「task」とします
+  # （実際に存在するクラス名と一致するテストデータの名前をつければ、そのクラスのテストデータを自動で作成します）
+  factory :task do
+    name { 'Factoryで作ったデフォルトのタイトル１' }
+    content { 'Factoryで作ったデフォルトのコンテント１' }
+  end
+
+  # 作成するテストデータの名前を「second_task」とします
+  # （存在しないクラス名の名前をつける場合、オプションで「このクラスのテストデータにしてください」と指定します）
+  factory :second_task, class: Task do
+    name { 'Factoryで作ったデフォルトのタイトル２' }
+    content { 'Factoryで作ったデフォルトのコンテント２' }
+  end
+end

--- a/spec/features/task.spec.rb
+++ b/spec/features/task.spec.rb
@@ -4,18 +4,14 @@ require 'rails_helper'
 # このRSpec.featureの右側に、「タスク管理機能」のように、テスト項目の名称を書きます（do ~ endでグループ化されています）
 RSpec.feature "タスク管理機能", type: :feature do
   # scenario（itのalias）の中に、確認したい各項目のテストの処理を書きます。
-  scenario "タスク一覧のテスト" do
+  background do
     # あらかじめタスク一覧のテストで使用するためのタスクを二つ作成する
-    Task.create!(name: 'test_task_01', content: 'postpostpost')
-    Task.create!(name: 'test_task_02', content: 'sample2sample2')
-
+    Task.create!(title: 'test_task_01', content: 'testtesttest')
+    Task.create!(title: 'test_task_02', content: 'mofmofmofmof')
+  end
+  scenario "タスク一覧のテスト" do
     # tasks_pathにvisitする（タスク一覧ページに遷移する）
     visit tasks_path
-
-    # 実際の状況を確認したい箇所にさし挟む。
-    # 例の場合、「タスクが保存された後、タスク一覧ページに行くとどうなるのか」を確認するため
-    # visit tasks_path の直後に save_and_open_page を挟んでいる
-
 
     # visitした（到着した）expect(page)に（タスク一覧ページに）「testtesttest」「samplesample」という文字列が
     # have_contentされているか？（含まれているか？）ということをexpectする（確認・期待する）テストを書いている
@@ -44,15 +40,16 @@ RSpec.feature "タスク管理機能", type: :feature do
   end
 
   scenario "タスク詳細のテスト" do
-    # あらかじめタスク一覧のテストで使用するためのタスクを二つ作成する
     Task.create!(name: 'test_task_03', content: 'test1test1test1')
+
     visit tasks_path
     page.first("#show").click
 
-    # visitした（到着した）expect(page)に（タスク一覧ページに）「testtesttest」「samplesample」という文字列が
-    # have_contentされているか？（含まれているか？）ということをexpectする（確認・期待する）テストを書いている
     expect(page).to have_content 'test_task_03'
     expect(page).to have_content 'test1test1test1'
     save_and_open_page
+  end
+
+  scinario "タスクが作成日時の降順に並んでいるかのテスト" do
   end
 end

--- a/spec/features/task.spec.rb
+++ b/spec/features/task.spec.rb
@@ -15,8 +15,8 @@ RSpec.feature "タスク管理機能", type: :feature do
 
     # visitした（到着した）expect(page)に（タスク一覧ページに）「testtesttest」「samplesample」という文字列が
     # have_contentされているか？（含まれているか？）ということをexpectする（確認・期待する）テストを書いている
-    expect(page).to have_content 'postpostpost'
-    expect(page).to have_content 'sample2sample2'
+    expect(page).to have_content 'Factoryで作ったデフォルトのタイトル１'
+    expect(page).to have_content 'Factoryで作ったデフォルトのコンテント１'
   end
 
   scenario "タスク作成のテスト" do
@@ -27,16 +27,17 @@ RSpec.feature "タスク管理機能", type: :feature do
     # タスクのタイトルと内容をそれぞれfill_in（入力）する
     # 2.ここに「タスク名」というラベル名の入力欄に内容をfill_in（入力）する処理を書く
     # 3.ここに「タスク詳細」というラベル名の入力欄に内容をfill_in（入力）する処理を書く
-    fill_in 'Name', with: 'Example Name'
-    fill_in 'Content', with: 'Example content'
+    fill_in 'タスク名', with: 'Factoryで作ったデフォルトのタイトル１'
+
+    fill_in 'タスク詳細', with: 'Factoryで作ったデフォルトのコンテント１'
     # 「登録する」というvalue（表記文字）のあるボタンをclick_onする（クリックする）
     # 4.「登録する」というvalue（表記文字）のあるボタンをclick_onする（クリックする）する処理を書く
-    click_on 'Create Task'
+    click_on '登録する'
     # clickで登録されたはずの情報が、タスク詳細ページに表示されているかを確認する
     # （タスクが登録されたらタスク詳細画面に遷移されるという前提）
     # 5.タスク詳細ページに、テストコードで作成したはずのデータ（記述）がhave_contentされているか（含まれているか）を確認（期待）するコードを書く
-    expect(page).to have_content 'Example Name'
-    expect(page).to have_content 'Example content'
+    expect(page).to have_content 'Factoryで作ったデフォルトのタイトル１'
+    expect(page).to have_content 'Factoryで作ったデフォルトのコンテント１'
   end
 
   scenario "タスク詳細のテスト" do
@@ -50,6 +51,7 @@ RSpec.feature "タスク管理機能", type: :feature do
     save_and_open_page
   end
 
-  scinario "タスクが作成日時の降順に並んでいるかのテスト" do
+  scenario "タスクが作成日時の降順に並んでいるかのテスト" do
+    
   end
 end

--- a/spec/features/task.spec.rb
+++ b/spec/features/task.spec.rb
@@ -6,8 +6,8 @@ RSpec.feature "タスク管理機能", type: :feature do
   # scenario（itのalias）の中に、確認したい各項目のテストの処理を書きます。
   background do
     # あらかじめタスク一覧のテストで使用するためのタスクを二つ作成する
-    Task.create!(title: 'test_task_01', content: 'testtesttest')
-    Task.create!(title: 'test_task_02', content: 'mofmofmofmof')
+    FactoryBot.create(:task)
+    FactoryBot.create(:second_task)
   end
   scenario "タスク一覧のテスト" do
     # tasks_pathにvisitする（タスク一覧ページに遷移する）

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -33,7 +33,7 @@ end
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
-
+  config.include FactoryBot::Syntax::Methods
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.


### PR DESCRIPTION
タスク一覧を降順で表示されることのテスト実装

追加：
task_controller <------ indexアクションに降順指定

view/tasts/index <------- 一覧画面で作成日が表示されるように記述

tasks/ja.yml <-------- created_at の日本語指定

factories/task.rb・features/task.spec.rb <--------- factory_botを導入して降順テスト

